### PR TITLE
fix: restrict provider chains to active network

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,12 +11,11 @@ import {
 } from "@starknet-react/core"
 
 export default function Home() {
-  const chains = [mainnet, sepolia]
+  const chains = IS_MAINNET ? [mainnet] : [sepolia]
   /* const providers = publicProvider() */
 
   const mainnetJsonRpcProvider = jsonRpcProvider({
-    rpc: (chain) => {
-      console.log("mainnet", chain)
+    rpc: () => {
       return {
         nodeUrl: "https://rpc.starknet.lava.build",
       }
@@ -24,10 +23,10 @@ export default function Home() {
   })
 
   const sepoliaJsonRpcProvider = jsonRpcProvider({
-    rpc: (chain) => {
-      console.log("sepolia", chain)
+    rpc: () => {
       return {
-        nodeUrl: "https://api.hydrogen.argent47.net/v1/starknet/sepolia/rpc/v0.10",
+        nodeUrl:
+          "https://api.hydrogen.argent47.net/v1/starknet/sepolia/rpc/v0.10",
         specVersion: "0.10.2",
       }
     },

--- a/src/components/HeaderConnectButton.tsx
+++ b/src/components/HeaderConnectButton.tsx
@@ -1,3 +1,4 @@
+import { isUserRejectedRequest } from "@/helpers/isUserRejectedRequest"
 import { useConnect } from "@starknet-react/core"
 import { StarknetkitConnector, useStarknetkitConnectModal } from "starknetkit"
 
@@ -14,12 +15,18 @@ const HeaderConnectButton = () => {
       <button
         className="px-x md:px-12 bg-gradient-to-r from-nebula-from to-nebula-to text-white rounded-lg"
         onClick={async () => {
-          const { connector } = await starknetkitConnectModal()
-          if (!connector) {
-            // or throw error
-            return
+          try {
+            const { connector } = await starknetkitConnectModal()
+            if (!connector) {
+              return
+            }
+            await connectAsync({ connector })
+          } catch (error) {
+            if (isUserRejectedRequest(error)) {
+              return
+            }
+            throw error
           }
-          await connectAsync({ connector })
         }}
       >
         Connect wallet

--- a/src/components/connect/ConnectStarknetkitModal.tsx
+++ b/src/components/connect/ConnectStarknetkitModal.tsx
@@ -1,3 +1,4 @@
+import { isUserRejectedRequest } from "@/helpers/isUserRejectedRequest"
 import { useConnect } from "@starknet-react/core"
 import { StarknetkitConnector, useStarknetkitConnectModal } from "starknetkit"
 import { Button } from "../ui/Button"
@@ -14,12 +15,18 @@ const ConnectStarknetkitModal = () => {
     <Button
       className="w-full justify-center"
       onClick={async () => {
-        const { connector } = await starknetkitConnectModal()
-        if (!connector) {
-          // or throw error
-          return
+        try {
+          const { connector } = await starknetkitConnectModal()
+          if (!connector) {
+            return
+          }
+          await connectAsync({ connector })
+        } catch (error) {
+          if (isUserRejectedRequest(error)) {
+            return
+          }
+          throw error
         }
-        await connectAsync({ connector })
       }}
       hideChevron
     >

--- a/src/components/connect/ConnectorButton.tsx
+++ b/src/components/connect/ConnectorButton.tsx
@@ -1,3 +1,4 @@
+import { isUserRejectedRequest } from "@/helpers/isUserRejectedRequest"
 import { Connector, useConnect } from "@starknet-react/core"
 import { FC, ReactNode } from "react"
 import { Button } from "../ui/Button"
@@ -15,7 +16,14 @@ const ConnectorButton: FC<{ connector: Connector; icon: ReactNode }> = ({
     <Button
       key={connector.id}
       onClick={async () => {
-        await connectAsync({ connector })
+        try {
+          await connectAsync({ connector })
+        } catch (error) {
+          if (isUserRejectedRequest(error)) {
+            return
+          }
+          throw error
+        }
       }}
       className="bg-raisin-black h-10 text-sm leading-4 font-medium gap-2 justify-center hover:#262933"
       hideChevron

--- a/src/helpers/isUserRejectedRequest.ts
+++ b/src/helpers/isUserRejectedRequest.ts
@@ -1,0 +1,4 @@
+export const isUserRejectedRequest = (error: unknown) =>
+  error instanceof Error &&
+  (error.name === "UserRejectedRequestError" ||
+    /user rejected request/i.test(error.message))


### PR DESCRIPTION
## Summary

- Only pass the active network chain to `StarknetConfig` instead of always passing both mainnet and Sepolia.
- Remove provider debug logs that printed both chain objects in Production.
- Ignore wallet connect cancellation errors so user-rejected requests do not surface as unhandled console errors.

## Why

Production is configured for Sepolia/Hydrogen, but `StarknetConfig` was still receiving `[mainnet, sepolia]`. That allowed the Sepolia RPC provider to be invoked for the mainnet chain entry, which matched the duplicate `sepolia` console logs seen in the browser.

## Validation

- `pnpm build`
- `pnpm lint`
- `git diff --check`
